### PR TITLE
[PPA-5] - Configure JPA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,4 +19,4 @@ jobs:
           distribution: "temurin"
           cache: maven
       - name: mvn clean install
-        run: mvn clean install
+        run: mvn clean install -Dspring.profiles.active=default

--- a/README.md
+++ b/README.md
@@ -13,16 +13,18 @@ To avoid any unexpected behaviour, make sure you have installed the following to
 
 ## Running project locally
 
-1. To install third-party dependencies, make sure you run:
+1. Before start, make sure to provide your local database's credentials in `database-secrets.yml`.
+
+2. To install third-party dependencies, to create database schema and populate it with test data locally, make sure you run:
 
 ```bash
-mvn clean install
+mvn clean install -Dspring.profiles.active=dev
 ```
 
-2. Run with Spring Boot Maven plugin:
+3. Run with Spring Boot Maven plugin:
 
 ```bash
-mvn spring-boot:run
+mvn spring-boot:run -Dspring-boot.run.profiles=dev
 ```
 
 OR
@@ -32,7 +34,7 @@ OR
 ```bash
 mvn clean package
 
-java -jar target/pocket-pharmacy-api-0.0.1-SNAPSHOT.jar
+java -jar -Dspring.profiles.active=dev target/pocket-pharmacy-api-0.0.1-SNAPSHOT.jar
 ```
 
 4. To view endpoints, open [SwaggerUI](http://localhost:8080/swagger-ui.html) in your browser.

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,8 @@
 
         <!-- Project dependency versions -->
         <org.springdoc.version>1.6.7</org.springdoc.version>
+        <spring-boot.version>2.6.6</spring-boot.version>
+        <mysql-connector-java.version>8.0.28</mysql-connector-java.version>
 
         <!-- Maven plugin versions -->
         <jacoco.version>0.8.2</jacoco.version>
@@ -54,6 +56,16 @@
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-ui</artifactId>
             <version>${org.springdoc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <version>${spring-boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>${mysql-connector-java.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,22 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+    import: database-secrets.yml
+  datasource:
+    url: jdbc:mysql://${database.url}/pocket_pharmacy
+    username: ${database.username}
+    password: ${database.password}
+    sql:
+      init:
+        mode: always
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    generate-ddl: true
+    hibernate:
+      ddl-auto: create
+    database-platform: org.hibernate.dialect.MySQL5Dialect
+    properties:
+      hibernate:
+        format_sql: true
+    open-in-view: off

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,7 @@
-
+spring:
+  config:
+    activate:
+      on-profile: default
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration

--- a/src/main/resources/database-secrets.yml
+++ b/src/main/resources/database-secrets.yml
@@ -1,0 +1,5 @@
+# Never commit the values !
+database:
+  url:
+  username:
+  password:

--- a/src/main/resources/database-secrets.yml
+++ b/src/main/resources/database-secrets.yml
@@ -1,4 +1,4 @@
-# Never commit the values !
+# Never commit the values in this file !
 database:
   url:
   username:


### PR DESCRIPTION
### Story link: https://jbence.atlassian.net/browse/PPA-5

### :pencil2: Description

- Creating “default” and “dev” Spring profiles
- Configuring that the build GitHub workflow run the “default” profile without JPA connection during ‘mvn clean install’
- Storing database connection credentials in a configuration file
- Updating README according to changes
