### PR TITLE
[PPA-8] - Configure H2 for 'default' Spring profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,11 @@
             <artifactId>mysql-connector-java</artifactId>
             <version>${mysql-connector-java.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,3 @@ spring:
   config:
     activate:
       on-profile: default
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,3 +2,12 @@ spring:
   config:
     activate:
       on-profile: default
+  datasource:
+    url: jdbc:h2:mem:pocket_pharmacy
+    username: test-user
+    password: 12345
+    driverClassName: org.h2.Driver
+    jpa:
+      spring.jpa.database-platform: org.hibernate.dialect.H2Dialect
+  h2:
+    console.enabled: true


### PR DESCRIPTION
### Story link: https://jbence.atlassian.net/browse/PPA-8

### :pencil2: Description

- After ‘default’ profile’s build is not breaking on GitHub by switching off JPA autoconfiguration in application.yml, but later will if @Repository components will added to data access components. To workaroung this, it’s a good candidate to configuring a simple, in-memory database for ‘default’ profile and allowing JPA autoconfiguring again.
- https://www.baeldung.com/spring-boot-h2-database
